### PR TITLE
Added the measure argument to all the queries to measure the time it takes for Prometheus client to respond

### DIFF
--- a/internal/server.go
+++ b/internal/server.go
@@ -21,9 +21,10 @@ func logJSONError(w http.ResponseWriter, err error, code int) {
 
 func parseQueryParameters(urlQuery url.Values) (queryParameters, error) {
 	return queryParameters{
-		namespace: urlQuery.Get("namespace"),
-		start:     urlQuery.Get("start"),
-		end:       urlQuery.Get("end"),
+		namespace:     urlQuery.Get("namespace"),
+		start:         urlQuery.Get("start"),
+		end:           urlQuery.Get("end"),
+		measureTiming: urlQuery.Get("measure") == "true",
 	}, nil
 }
 func handlerFactory(query string, prometheusClient prometheus) func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
There is an extra argument on the query, which measures the time it took. 
The code decodes and reencodes JSON with the time value added